### PR TITLE
HBASE-24054

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -409,6 +409,7 @@ public class HttpServer implements FilterContainer {
         httpConfig.setHeaderCacheSize(DEFAULT_MAX_HEADER_SIZE);
         httpConfig.setResponseHeaderSize(DEFAULT_MAX_HEADER_SIZE);
         httpConfig.setRequestHeaderSize(DEFAULT_MAX_HEADER_SIZE);
+        httpConfig.setSendServerVersion(false);
 
         if ("http".equals(scheme)) {
           listener = new ServerConnector(server.webServer, new HttpConnectionFactory(httpConfig));


### PR DESCRIPTION
To be safe, jetty's version number should be blocked.